### PR TITLE
docs: add AGENTS.md and correct stale README paths

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,162 @@
+# AGENTS.md — homelab-argo-gitops
+
+Day-1+ GitOps repo for the Sunnyside homelab. ArgoCD renders Kustomize overlays
+from this repo onto two single-node K3s clusters. Day-0 cluster build lives in the
+sibling repo `homelab-ansible-bootstrap` (which has its own AGENTS.md).
+
+Human-facing docs are in [README.md](README.md). This file covers what an agent
+needs to change things safely.
+
+## The one thing to understand first
+
+Two branches, two clusters, two different render paths:
+
+| Env | Branch | ArgoCD path it renders | Sync |
+|---|---|---|---|
+| staging (192.168.1.251) | `main` | `envs/staging/<ns>` | auto (prune + selfHeal) |
+| prod (192.168.1.173) | `prod` | **`base/<ns>`** | manual |
+
+Prod renders `base/` *directly* — see [argocd/prod/apps.yaml](argocd/prod/apps.yaml).
+`envs/prod/` only holds the monitoring overlay and sealed secrets. Consequences:
+
+- **`base/` is production.** An edit to `base/` is a prod change staged on `main`;
+  it ships the moment someone fast-forwards `prod` and syncs.
+- Staging is `base/` + hostname patches. `envs/staging/<ns>/kustomization.yaml`
+  rewrites every Ingress host to the `staging-` prefix.
+- `envs/prod/kustomization.yaml` and `envs/staging/kustomization.yaml` (the two
+  root-level ones listing all five namespaces) are **vestigial** — nothing renders
+  them. Don't add to them expecting an effect.
+
+Merging to `main` deploys to staging by itself. Reaching prod needs two deliberate
+steps: fast-forward the `prod` branch (Actions → *Promote to Prod*, or
+`git checkout prod && git merge main --ff-only && git push`), then
+`argocd app sync -l env=prod`. Never commit directly on `prod`; it must stay a
+fast-forward of `main`.
+
+## Layout
+
+```
+base/<namespace>/<service>/     # canonical manifests = prod
+  deployment.yaml service.yaml ingress.yaml pvc.yaml kustomization.yaml
+base/<namespace>/kustomization.yaml     # lists the service dirs
+base/monitoring/                # Helm values + ingress + exporters/
+envs/staging/<namespace>/       # base + staging- hostname patches
+envs/<env>/monitoring/          # per-env Helm values, ingress, sealed-secrets
+argocd/<env>/apps.yaml          # ApplicationSet (Kustomize apps) + monitoring Application
+```
+
+Namespaces: `utilities`, `media`, `productivity`, `infra`, `monitoring`.
+
+## Adding a service — the full checklist
+
+Missing step 3 is the classic failure: staging and prod both claim the bare
+hostname, and two clusters fight over one cert/DNS name.
+
+1. `base/<ns>/<service>/` with `deployment.yaml`, `service.yaml`, `ingress.yaml`,
+   `pvc.yaml` (if stateful) and a `kustomization.yaml` listing them.
+2. Add the directory to `base/<ns>/kustomization.yaml`.
+3. **Add an Ingress host patch to `envs/staging/<ns>/kustomization.yaml`** —
+   host, `tls[0].hosts[0]`, and `tls[0].secretName`, all prefixed `staging-`.
+4. Add a tile to `base/utilities/homepage/config/services.yaml` **and** the staging
+   copy `envs/staging/utilities/homepage-config/services.yaml` (they are separate
+   files; the staging one uses `staging-` URLs).
+5. Verify the render (below), then commit to `main`.
+6. Out-of-repo: DNS A record for the new hostname (both `svc.` and `staging-svc.`).
+
+## Manifest conventions
+
+Copy [base/media/sonarr/](base/media/sonarr/) as the reference shape.
+
+- Every object sets `metadata.namespace` explicitly and carries
+  `app.kubernetes.io/name: <service>` + `app.kubernetes.io/part-of: homelab`.
+  The Deployment selector matches on `app.kubernetes.io/name` only.
+- Service is `ClusterIP`, `port: 80` → `targetPort: <container port>`. Ingress
+  always points at port 80, so the container port never leaks into the Ingress.
+- Ingress: `ingressClassName: traefik`, annotation
+  `cert-manager.io/cluster-issuer: stepca-acme`, TLS secret named `<service>-tls`.
+- `TZ: Europe/Dublin` everywhere; `PUID`/`PGID` `"1000"` on linuxserver images.
+- Resource requests *and* limits on every container — these are small nodes and
+  staging has been OOM-killed before.
+- Liveness + readiness probes (tcpSocket is the norm for the *arr stack).
+- Config PVCs: `storageClassName: nfs-client`, RWO, a few Gi. Bulk media is
+  mounted as inline `nfs:` volumes from `192.168.1.202`, not PVCs.
+- Multi-workload apps get one file per Deployment in the same directory
+  (`deployment-db.yaml`, `deployment-worker.yaml`, …) — see
+  [base/utilities/firecrawl/](base/utilities/firecrawl/).
+
+## Traps
+
+**JSON6902 patches index into arrays by position.** Staging patches contain paths
+like `/spec/template/spec/containers/1/env/9/value`
+([envs/staging/productivity/kustomization.yaml](envs/staging/productivity/kustomization.yaml)
+patches Nextcloud this way, and the homepage Deployment patch uses `env/1`).
+Reordering or inserting an env var in a `base/` Deployment silently re-points the
+staging patch at the wrong key — it does not error. After touching env lists in
+`base/`, re-render the staging overlay and diff the patched fields.
+
+**Homepage config rides on the ConfigMap hash.** The Deployment mounts
+`services.yaml`/`settings.yaml` with `subPath`, and Kubernetes never propagates
+ConfigMap edits into a subPath mount. `configMapGenerator` gives the ConfigMap a
+content-hash suffix, so an edit changes the name, changes the volume reference,
+and rolls the pod. Never set `disableNameSuffixHash`, and keep the staging
+override as `behavior: replace` (not a new generator). See
+[base/utilities/homepage/kustomization.yaml](base/utilities/homepage/kustomization.yaml).
+The prod tiles are `base/utilities/homepage/config/services.yaml`; staging has its own
+copy at `envs/staging/utilities/homepage-config/services.yaml`. Edit both.
+
+**SealedSecrets are per-cluster.** Each cluster has its own key, so a secret must
+be sealed twice — once into `envs/staging/<ns>/sealed-secrets/`, once into
+`envs/prod/<ns>/sealed-secrets/`. Never copy a sealed file between environments.
+Today only `monitoring` has any. `vpn-credentials` (media) and the inline DB
+passwords in Deployment envs are *not* sealed yet — don't treat a plaintext
+password in a `base/` Deployment as a bug you should silently "fix" by inventing
+a secret; it changes the rollout.
+
+**Monitoring is Helm, not Kustomize.** `kube-prometheus-stack` is a multi-source
+ArgoCD Application: chart from the Prometheus community repo, values from
+`$values/base/monitoring/values.yaml` (prod) or
+`$values/envs/staging/monitoring/values.yaml` (staging), plus a Kustomize path for
+ingress/exporters/sealed-secrets. Prod sets `skipCrds: true`; staging does not.
+Staging values are deliberately smaller (2Gi retention, trimmed dashboards) — do
+not sync the two files. Grafana's Service name differs per env
+(`prod-monitoring-grafana` vs `staging-monitoring-grafana`), which is why the
+ingress is duplicated rather than patched.
+
+**Don't `kubectl apply` to the clusters to "fix" something.** Staging self-heals
+and will revert you; prod does not self-heal and will silently drift from git.
+Change the manifest.
+
+## Verify before committing
+
+```bash
+for d in envs/staging/utilities envs/staging/media envs/staging/productivity envs/staging/infra envs/staging/monitoring base/utilities base/media base/productivity base/infra envs/prod/monitoring; do echo "--- $d"; kubectl kustomize "$d" >/dev/null || echo "FAILED: $d"; done
+```
+
+Both the staging path and the corresponding `base/` path must build — prod renders
+`base/` directly, so a `base/` build failure breaks prod even if staging is fine.
+
+To inspect what actually changed in a rendered overlay:
+
+```bash
+kubectl kustomize envs/staging/utilities | grep -A3 'host:'
+```
+
+Cluster state (kubeconfig contexts exist for both clusters):
+
+```bash
+kubectl -n argocd get applications
+```
+
+## Renovate
+
+[renovate.json](renovate.json) scans Mondays 08:00 Europe/Dublin against `main`.
+Patch/digest bumps of container images auto-merge (→ straight to staging); Helm
+updates are grouped; major bumps of `postgres`/`redis` are disabled because they
+need a manual DB migration. Most images are `:latest`, so Renovate pins them to
+digests. Don't hand-pin an image tag without checking whether Renovate already
+manages it.
+
+## Commits
+
+Conventional Commits, imperative, lowercase subject: `feat:`, `fix:`, `docs:`,
+`chore:`. Scope only where it clarifies (`chore(renovate): …`). PRs against `main`.

--- a/README.md
+++ b/README.md
@@ -21,12 +21,14 @@ homelab-argo-gitops/
 │   ├── infra/                     # guacamole, uptime-kuma, netalertx
 │   └── monitoring/                # kube-prometheus-stack (Helm values)
 ├── envs/
-│   ├── staging/                   # Overlay: staging-specific patches
-│   │   ├── kustomization.yaml
-│   │   └── sealed-secrets/
-│   └── prod/                      # Overlay: prod-specific patches
-│       ├── kustomization.yaml
-│       └── sealed-secrets/
+│   ├── staging/                   # Overlay per namespace: staging- hostname patches
+│   │   ├── utilities/             # (+ homepage-config/ — staging dashboard)
+│   │   ├── media/
+│   │   ├── productivity/
+│   │   ├── infra/
+│   │   └── monitoring/            # staging Helm values, ingress, sealed-secrets/
+│   └── prod/                      # Prod renders base/ directly — only monitoring
+│       └── monitoring/            # prod ingress + exporters + sealed-secrets/
 ├── argocd/
 │   ├── staging/
 │   │   └── apps.yaml              # ArgoCD ApplicationSet (tracks main branch)
@@ -38,10 +40,13 @@ homelab-argo-gitops/
 
 ## Environments
 
-| Environment | Branch | Sync Policy | Cluster |
-|-------------|--------|-------------|---------|
-| staging | `main` | Auto-sync (prune + self-heal) | k3s-staging (192.168.1.251) |
-| prod | `prod` | Manual sync | k3s-prod (192.168.1.173) |
+| Environment | Branch | Renders | Sync Policy | Cluster |
+|-------------|--------|---------|-------------|---------|
+| staging | `main` | `envs/staging/<ns>` | Auto-sync (prune + self-heal) | k3s-staging (192.168.1.251) |
+| prod | `prod` | `base/<ns>` | Manual sync | k3s-prod (192.168.1.173) |
+
+Note that **prod renders `base/` directly** — there is no per-namespace prod overlay.
+`base/` is production; the staging overlay is base plus `staging-` hostname patches.
 
 Staging auto-syncs from `main` — merging a PR deploys it.
 
@@ -123,17 +128,26 @@ Configuration: [`renovate.json`](renovate.json)
 
 1. Create `base/<namespace>/<service>/` with `deployment.yaml`, `service.yaml`, `ingress.yaml`, and `kustomization.yaml`
 2. Add the service directory to `base/<namespace>/kustomization.yaml`
-3. No changes needed in `envs/` — Kustomize overlays inherit from base automatically
-4. Commit and push. ArgoCD picks it up on next sync
-5. Add the service to the Homepage dashboard config in `base/utilities/homepage/configmap.yaml`
-6. Add a DNS A record and `/etc/hosts` entry for the new service
+3. Add an Ingress host patch to `envs/staging/<namespace>/kustomization.yaml` — rewrite
+   `host`, `tls[0].hosts[0]` and `tls[0].secretName` to the `staging-` prefix. **Don't skip
+   this**: without it staging inherits the bare hostname from base and both clusters claim
+   the same name.
+4. Add the service to the Homepage dashboard in *both* config files —
+   `base/utilities/homepage/config/services.yaml` (prod URLs) and
+   `envs/staging/utilities/homepage-config/services.yaml` (staging URLs)
+5. Check the render before committing:
+   `kubectl kustomize base/<namespace>` and `kubectl kustomize envs/staging/<namespace>`
+6. Commit and push to `main`. Staging auto-syncs; prod needs a promote + sync
+7. Add a DNS A record and `/etc/hosts` entry for both hostnames
 
 ## How To: Override a Value for One Environment
 
-Create a patch file in `envs/<env>/` and reference it in the environment's `kustomization.yaml`:
+Staging patches live in `envs/staging/<namespace>/kustomization.yaml` — either inline (as the
+existing hostname patches are) or as a separate file referenced from `patches:`. Prod has no
+per-namespace overlay, so a prod-only value has to be the value in `base/`.
 
 ```yaml
-# envs/staging/my-service-patch.yaml
+# envs/staging/<namespace>/my-service-patch.yaml
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -147,7 +161,10 @@ spec:
 
 Secrets are managed with [SealedSecrets](https://sealed-secrets.netlify.app/). Each cluster has its own encryption key, so secrets must be sealed per environment.
 
-Sealed secret files live in `envs/<env>/<namespace>/sealed-secrets/`.
+Sealed secret files live in `envs/<env>/<namespace>/sealed-secrets/` — today only
+`monitoring` has any (`envs/staging/monitoring/sealed-secrets/` and
+`envs/prod/monitoring/sealed-secrets/`). The same secret must be sealed twice, once per
+cluster; a sealed file is never portable between environments.
 
 Other secrets not yet migrated to SealedSecrets:
 - `vpn-credentials` (media namespace) — VPN provider credentials for gluetun/qbittorrent


### PR DESCRIPTION
## Summary

Adds an agent-facing `AGENTS.md`, and fixes the README claims that were wrong because of a single misconception: that prod uses an `envs/prod/` overlay.

Prod's ApplicationSet renders `base/<ns>` **directly** — `base/` *is* production, and `envs/prod/` holds only the monitoring overlay. The two root-level `envs/*/kustomization.yaml` files are vestigial; nothing renders them.

## README fixes

- **Repo-structure tree** — shows the real `envs/` shape: per-namespace staging overlays (plus `homepage-config/`), and `envs/prod/` holding only `monitoring/`.
- **Environments table** — gains a *Renders* column (`envs/staging/<ns>` vs `base/<ns>`).
- **Add a New Service** — step 3 said "No changes needed in `envs/`". That's the dangerous one: without the staging Ingress host patch, staging inherits the bare hostname from base and both clusters claim the same name. Replaced with the real patch step, the two separate homepage config files, and a `kubectl kustomize` check before committing.
- **Override a Value** — no longer implies a per-namespace prod overlay exists.
- **Homepage config path** — `base/utilities/homepage/config/services.yaml`, not the `configmap.yaml` that never existed.
- **Secrets** — notes only `monitoring` is sealed today, and that a sealed file is never portable between clusters.

## AGENTS.md

Covers the add-a-service checklist, the manifest conventions (drawn from `base/media/sonarr/`), and four traps that don't announce themselves:

- JSON6902 staging patches index env vars **by position** (`env/9/value`), so reordering a base env list silently re-points the patch — no error.
- The homepage ConfigMap content hash *is* the rollout mechanism (subPath mounts never propagate ConfigMap edits), so `disableNameSuffixHash` must stay off.
- SealedSecrets use per-cluster keys and can never be copied between environments.
- Monitoring is a multi-source Helm app whose staging/prod values are deliberately divergent.

## Verification

Docs only — no manifest changes, so no deployment impact when this merges to `main`. `kubectl kustomize` was run across all ten rendered paths (four staging namespaces, four base namespaces, both monitoring overlays) and all build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)