### PR TITLE
chore(renovate): track ArgoCD chart pins, bump kube-prometheus-stack to 90.0.0

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -156,6 +156,31 @@ need a manual DB migration. Most images are `:latest`, so Renovate pins them to
 digests. Don't hand-pin an image tag without checking whether Renovate already
 manages it.
 
+Three managers are configured, and the distinction matters:
+
+- `kubernetes` — image tags in every `*.yaml`. This is what most PRs come from.
+- `helm-values` — images referenced inside `base/monitoring/values.yaml` and the
+  staging copy. Enabled by default; no config needed.
+- `argocd` — the Helm chart pins inside `argocd/*/apps.yaml`
+  (`spec.sources[].chart` + `targetRevision`). **This manager ships disabled** —
+  it has no default file patterns — so without the explicit block in
+  `renovate.json` those pins are invisible and drift silently. They did: the
+  `kube-prometheus-stack` pin sat 8 majors behind before this was noticed.
+
+Chart bumps never auto-merge. A chart carries CRDs and a values schema, and prod
+runs `skipCrds: true`, so its CRDs are applied by hand — an unattended chart merge
+would leave the operator and its CRDs at different versions. Before taking a chart
+PR, render both values files against the new version:
+
+```bash
+helm template kps prometheus-community/kube-prometheus-stack --version <new> \
+  -f base/monitoring/values.yaml --namespace monitoring --skip-crds >/dev/null
+```
+
+Note that editing `argocd/*/apps.yaml` changes nothing on a cluster by itself —
+those manifests are applied by hand (see the Ansible repo's AGENTS.md). A chart
+bump here is staged until someone runs `kubectl apply -f argocd/<env>/apps.yaml`.
+
 ## Commits
 
 Conventional Commits, imperative, lowercase subject: `feat:`, `fix:`, `docs:`,

--- a/README.md
+++ b/README.md
@@ -107,10 +107,18 @@ Prod also has no `selfHeal`, so manual `kubectl` changes on the prod cluster wil
 
 [Renovate](https://github.com/renovatebot/renovate) scans this repo weekly (Monday 8am, Europe/Dublin) for:
 
-- Outdated container image tags
-- Helm chart version updates
+- Container image tags in the Kustomize manifests (`kubernetes` manager)
+- Images referenced inside the monitoring Helm values (`helm-values` manager)
+- Helm chart pins inside `argocd/*/apps.yaml` (`argocd` manager)
+- GitHub Actions versions
 
 Renovate opens PRs against `main`. Merging a PR auto-deploys to staging. When verified, promote to prod using the workflow above.
+
+Image patch/digest updates auto-merge. **Helm chart updates never do** — a chart carries CRDs and a values schema, and prod runs with `skipCrds: true`, so its CRDs are applied by hand. Major bumps of `postgres` and `redis` are disabled outright; they need a manual DB migration.
+
+Note the `argocd` manager has no default file patterns — it is off unless explicitly configured. It wasn't, which is why the `kube-prometheus-stack` pin drifted eight majors behind before anyone noticed.
+
+Chart pins in `argocd/*/apps.yaml` only reach a cluster when someone runs `kubectl apply -f argocd/<env>/apps.yaml`; those manifests are not self-applying.
 
 Configuration: [`renovate.json`](renovate.json)
 

--- a/argocd/prod/apps.yaml
+++ b/argocd/prod/apps.yaml
@@ -58,7 +58,7 @@ spec:
     # Helm chart for kube-prometheus-stack
     - repoURL: https://prometheus-community.github.io/helm-charts
       chart: kube-prometheus-stack
-      targetRevision: "82.17.1"
+      targetRevision: "90.0.0"
       helm:
         skipCrds: true
         valueFiles:

--- a/argocd/staging/apps.yaml
+++ b/argocd/staging/apps.yaml
@@ -61,7 +61,7 @@ spec:
     # Helm chart for kube-prometheus-stack
     - repoURL: https://prometheus-community.github.io/helm-charts
       chart: kube-prometheus-stack
-      targetRevision: "82.17.1"
+      targetRevision: "90.0.0"
       helm:
         valueFiles:
           - $values/envs/staging/monitoring/values.yaml

--- a/renovate.json
+++ b/renovate.json
@@ -5,10 +5,11 @@
   ],
   "baseBranches": ["main"],
   "kubernetes": {
-    "fileMatch": ["\\.yaml$"]
+    "managerFilePatterns": ["/\\.yaml$/"]
   },
-  "helmv3": {
-    "fileMatch": ["argocd/.+\\.yaml$"]
+  "argocd": {
+    "description": "Track Helm chart pins inside ArgoCD Application/ApplicationSet manifests (e.g. kube-prometheus-stack in argocd/*/apps.yaml). The argocd manager ships disabled — it has no default file patterns — so this block is what makes those pins visible at all.",
+    "managerFilePatterns": ["/^argocd/.+\\.yaml$/"]
   },
   "packageRules": [
     {
@@ -22,6 +23,11 @@
       "description": "Group all Helm chart updates",
       "matchDatasources": ["helm"],
       "groupName": "helm-charts"
+    },
+    {
+      "description": "Never auto-merge a Helm chart bump — charts carry CRDs and values-schema changes, and prod runs with skipCrds: true so CRDs are applied by hand",
+      "matchDatasources": ["helm"],
+      "automerge": false
     },
     {
       "description": "Pin latest tags to digests for reproducibility",


### PR DESCRIPTION
## The bug

`renovate.json` pointed the **`helmv3`** manager at `argocd/.+\.yaml$`. But `helmv3` parses `Chart.yaml` dependency blocks — it has no idea what an ArgoCD Application's `spec.sources[].chart` is. The manager that reads those is **`argocd`**, which ships with no default file patterns and was never enabled.

So the chart pins in `argocd/*/apps.yaml` were invisible to Renovate. Confirmed on the dependency dashboard: neither `argocd/staging/apps.yaml` nor `argocd/prod/apps.yaml` appears anywhere under Detected Dependencies, and no Helm PR has ever been opened despite the `helm-charts` group rule sitting in the config.

Unnoticed, `kube-prometheus-stack` drifted **eight majors** behind — pinned `82.17.1`, latest `90.0.0`.

## Changes

- Enable the `argocd` manager so those pins are tracked from now on.
- Bump `kube-prometheus-stack` `82.17.1` → `90.0.0` in both `argocd/staging/apps.yaml` and `argocd/prod/apps.yaml`.
- Migrate `fileMatch` → `managerFilePatterns` (Renovate was prompting for the config migration on the dashboard).
- New rule: **Helm bumps never auto-merge.** A chart carries CRDs and a values schema, and prod runs `skipCrds: true`, so an unattended merge could leave the operator and its CRDs at different versions.
- README + AGENTS.md document which managers are configured and why the `argocd` one has to be explicit.

## Verification

Both values files render clean against 90.0.0, so the values schema is still compatible:

```
helm template kps prometheus-community/kube-prometheus-stack --version 90.0.0 \
  -f base/monitoring/values.yaml --namespace monitoring --skip-crds   # OK
helm template kps prometheus-community/kube-prometheus-stack --version 90.0.0 \
  -f envs/staging/monitoring/values.yaml --namespace monitoring       # OK
```

`renovate.json` validated with `renovate-config-validator` against `renovate@latest` (the default `npx renovate` resolves to v37, which predates `managerFilePatterns` and reports a false error — worth knowing if you re-check this).

All ten Kustomize paths still build.

## Before you merge

The chart bump changes nothing on its own — `argocd/*/apps.yaml` is applied by hand, so it's staged until someone runs `kubectl apply -f argocd/<env>/apps.yaml`. Take staging first.

**Prod runs `skipCrds: true`**, so its prometheus-operator CRDs are not managed by the chart and need updating separately before prod picks this up. Staging will pull CRDs from the chart itself.

I did not touch the image-tag PRs already open (#3, #4, #6, #8, #9, #11). Note #4 and #11 both target unpoller — v2.39.0 and a v2→v5 major. Don't merge both.

🤖 Generated with [Claude Code](https://claude.com/claude-code)